### PR TITLE
add support for additional key parsing for variableMaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project uses [semantic versioning](http://semver.org/).
 
+## [2.1.0] 2022-07-21
+Add support for additional keys that do not start with <site.> in variableMaps.
+
 ## [2.0.1] 2022-02-17
 Fix table generation bug when table cell content begins with formatting like bold or italics.
 

--- a/lib/htmlGenerator2.js
+++ b/lib/htmlGenerator2.js
@@ -582,15 +582,24 @@ function replaceVariables(text, variableMaps) {
 			*/
 			for (var i = variableMaps.length - 1; i >= 0; i--) {
 				if (variableMaps[i]) {
-					var temp = key.split(".").reduce(
-						function get(result, currentKey) {
-							if (result) { /* result may be null if content is not valid yaml */
-								return result[currentKey];
+					if(!key.startsWith('site.')){
+						if(variableMaps[i][key]) {
+							let temp = variableMaps[i][key];
+							if (temp) {
+								value = temp;
 							}
-						},
-						variableMaps[i]);
-					if (temp) {
-						value = temp;
+						}
+					} else {
+						var temp = key.split(".").reduce(
+							function get(result, currentKey) {
+								if (result) { /* result may be null if content is not valid yaml */
+									return result[currentKey];
+								}
+							},
+							variableMaps[i]);
+						if (temp) {
+							value = temp;
+						}
 					}
 				}
 			}

--- a/lib/htmlGenerator2.js
+++ b/lib/htmlGenerator2.js
@@ -1,7 +1,7 @@
 /**
  * marked-it
  *
- * Copyright (c) 2021 IBM Corporation
+ * Copyright (c) 2021, 2022 IBM Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
  * and associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -582,23 +582,21 @@ function replaceVariables(text, variableMaps) {
 			*/
 			for (var i = variableMaps.length - 1; i >= 0; i--) {
 				if (variableMaps[i]) {
-					if(!key.startsWith('site.')){
-						if(variableMaps[i][key]) {
-							let temp = variableMaps[i][key];
-							if (temp) {
-								value = temp;
-							}
-						}
-					} else {
+					if (key.startsWith('site.')) {
 						var temp = key.split(".").reduce(
 							function get(result, currentKey) {
 								if (result) { /* result may be null if content is not valid yaml */
 									return result[currentKey];
 								}
 							},
-							variableMaps[i]);
+							variableMaps[i]
+						);
 						if (temp) {
 							value = temp;
+						}
+					} else {
+						if (variableMaps[i][key]) {
+							value = variableMaps[i][key];
 						}
 					}
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "marked-it-core",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "marked-it-core",
 	"description": "A Marked-backed Markdown->HTML generator.  Supports extended attribute and front matter syntaxes, and provides hooks for modifying the generated HTML.",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"author": "Grant Gayed <grant_gayed@ca.ibm.com>",
 	"license": "MIT",
 	"homepage": "https://github.com/ibm/marked-it",


### PR DESCRIPTION
For https://github.ibm.com/Bluemix/Bluemix-doc-framework/issues/4312, https://github.ibm.com/Bluemix/Bluemix-doc-framework/issues/4350

Changes proposed:
* add support for additional keys that does not start with <site.> in variableMaps